### PR TITLE
Adding methods to query the frame rate and target frame rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mixedreality.visualprofiler",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "displayName": "MRTK Visual Profiler",
   "description": "Provides a drop in solution for viewing your mixed reality Unity application's frame rate, scene complexity, and memory usage.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview
Adding methods to query the smoothed frame rate and target frame rate via script.

For example, one can now log the smoothed frame rate or target frame rate:

```
using Microsoft.MixedReality.Profiling;
using UnityEngine;

public class Test : MonoBehaviour
{
    public VisualProfiler profiler;

    void Update()
    {
        Debug.Log(profiler.SmoothCpuFrameRate);
        Debug.Log(profiler.SmoothGpuFrameRate);
        Debug.Log(profiler.TargetFrameRate);
    }
}
```

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
