### PR TITLE
Add support for other ProfilerMarker unit types

### DIFF
--- a/com.microsoft.mixedreality.visualprofiler/VisualProfiler.cs
+++ b/com.microsoft.mixedreality.visualprofiler/VisualProfiler.cs
@@ -360,7 +360,7 @@ namespace Microsoft.MixedReality.Profiling
                     switch (MarkerUnitType)
                     {
                         case ProfilerMarkerDataUnit.TimeNanoseconds: DisplayUnitSuffix = "ms"; break;
-                        case ProfilerMarkerDataUnit.Bytes: DisplayUnitSuffix = "kb/s"; break;
+                        case ProfilerMarkerDataUnit.Bytes: DisplayUnitSuffix = "kbps"; break;
                         case ProfilerMarkerDataUnit.Percent: DisplayUnitSuffix = "%"; break;
                         case ProfilerMarkerDataUnit.FrequencyHz: DisplayUnitSuffix = "hz"; break;
                         default: DisplayUnitSuffix = ""; break;
@@ -441,7 +441,7 @@ namespace Microsoft.MixedReality.Profiling
                 switch (MarkerUnitType)
                 {
                     case ProfilerMarkerDataUnit.TimeNanoseconds: return average * 1e-6f; // Milliseconds
-                    case ProfilerMarkerDataUnit.Bytes: return average / 125.0f; // Kilobytes/second
+                    case ProfilerMarkerDataUnit.Bytes: return average / 125.0f; // Kilobits/second
                     default: return average;
                 }
             }

--- a/com.microsoft.mixedreality.visualprofiler/VisualProfiler.cs
+++ b/com.microsoft.mixedreality.visualprofiler/VisualProfiler.cs
@@ -342,9 +342,8 @@ namespace Microsoft.MixedReality.Profiling
             public TextData Text { get; set; }
             public float LastValuePresented { get; set; }
             public bool HasEverPresented { get; set; }
-
-            public ProfilerMarkerDataUnit MarkerUnitType { get; private set; } = ProfilerMarkerDataUnit.Undefined;
-            public string DisplayUnitSuffix { get; private set; } = "";
+            public ProfilerMarkerDataUnit MarkerUnitType { get; private set; }
+            public string DisplayUnitSuffix { get; private set; }
 
             private bool running = false;
 
@@ -945,7 +944,7 @@ namespace Microsoft.MixedReality.Profiling
                     {
                         float value = profilerGroup.CalculateDisplayValue();
 
-                        if (WillDisplayedValueDiffer(profilerGroup.LastValuePresented, value, displayedDecimalDigits))
+                        if (WillDisplayedProfilerValueDiffer(profilerGroup.LastValuePresented, value, displayedDecimalDigits))
                         {
                             profilerGroup.HasEverPresented = true;
                             profilerGroup.LastValuePresented = value;
@@ -1507,34 +1506,6 @@ namespace Microsoft.MixedReality.Profiling
             SetText(data, buffer, bufferIndex, color, justifyLength);
         }
 
-        private void KilobytesPerSecondToString(char[] buffer, int displayedDecimalDigits, TextData data, float kilobytesPerSecond, Color color, int justifyLength = 0)
-        {
-            int bufferIndex = 0;
-
-            for (int i = 0; i < data.Prefix.Length; ++i)
-            {
-                buffer[bufferIndex++] = data.Prefix[i];
-            }
-
-            if (kilobytesPerSecond >= 0.0f)
-            {
-                bufferIndex = FtoA(kilobytesPerSecond, displayedDecimalDigits, buffer, bufferIndex);
-            }
-            else
-            {
-                buffer[bufferIndex++] = '-';
-                buffer[bufferIndex++] = '.';
-                buffer[bufferIndex++] = '-';
-            }
-
-            buffer[bufferIndex++] = 'k';
-            buffer[bufferIndex++] = 'b';
-            buffer[bufferIndex++] = '/';
-            buffer[bufferIndex++] = 's';
-
-            SetText(data, buffer, bufferIndex, color, justifyLength);
-        }
-
         private Color QualityLevelBudgetToColor(int[] qualityLevelBudget, long value)
         {
             int level = QualitySettings.GetQualityLevel();
@@ -1640,7 +1611,7 @@ namespace Microsoft.MixedReality.Profiling
             }
         }
 
-        private static bool WillDisplayedValueDiffer(float oldValue, float newValue, int displayedDecimalDigits)
+        private static bool WillDisplayedProfilerValueDiffer(float oldValue, float newValue, int displayedDecimalDigits)
         {
             float decimalPower = Mathf.Pow(10.0f, displayedDecimalDigits);
 


### PR DESCRIPTION
## Overview
Adds support for other ProfilerRecorder unit types.

## Changes
Updates to the display code to handle a ProfilerGroup with a configurable Display Value / Unit Suffix
- `TimeNanoseconds` are displayed as milliseconds (current functionality)
- `Bytes` are displayed as kilobits/second
- Everything else is displayed as-is with an appropriate suffix if applicable

Example with a profiler tracking Bytes (displaying kilobits/second):
<img width="295" alt="image" src="https://github.com/microsoft/VisualProfiler-Unity/assets/54583751/52adc8c1-3587-4368-8bdd-a10a971d2fae">


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
